### PR TITLE
Made terminal work again, removed choice of terminal

### DIFF
--- a/trunk/Main_crava.cpp
+++ b/trunk/Main_crava.cpp
@@ -893,44 +893,23 @@ void Main_crava::on_wikiAction_triggered(){
 	}
 }
 void Main_crava::on_runAction_triggered(){
-	if(!currentFile().isEmpty()){//this is nowhere near platform independent... only works on linux, unfortunately the terminals do not have the same syntax so require hacks to get it to work properly, if there was a terminal widget that might have been better.
+	if(!currentFile().isEmpty()){//only works on linux
 		QSettings settings("Statoil","CRAVA");
 		settings.beginGroup("crava");
-		QString program;
+		QString program = "konsole";
 		QStringList arguments;
-		if(settings.value(QString("useterminal"),true).toBool()){
-			program=settings.value(QString("terminal"),QString("konsole")).toString();
-			if(program==QString("gnome-terminal")){//sets title of window
-				arguments << QString("-t");
-			}
-			else{
-				arguments << QString("-T");
-			}
-			arguments << QString(StandardStrings::cravaVersion() + QString(" ") + StandardStrings::strippedName(currentFile()));
-			if(program==QString("konsole")){//these flags only work for konsole
-				arguments << QString("--workdir");//sets working directory
-				if(!top_directoryPointer->text(1).isEmpty()){
-					arguments << top_directoryPointer->text(1);
-				}
-				else{
-					arguments << QString(".");
-				}
-				arguments << QString("--noclose");//makes the terminal not close on exit
-			}
-			
-			if(program==QString("gnome-terminal")){//sets executable
-				arguments << QString("-x");
-				arguments << QString(settings.value(QString("executable"),QString()).toString());
-			}
-			else{
-				arguments << QString("-e");
-				arguments << settings.value(QString("executable"),QString()).toString();
-			}
+		arguments << QString("--workdir");//sets working directory
+		// Set working directory to top-directory tag if it exists, else use current directory
+		if(!top_directoryPointer->text(1).isEmpty()){
+			arguments << top_directoryPointer->text(1);
 		}
-		else{//if it is to not run in terminal, just start the program directly
-			program=settings.value(QString("executable"),QString()).toString();
+		else{
+		  arguments << QString(".");
 		}
-		arguments << currentFile();
+		arguments << QString("--noclose"); //makes the terminal not close on exit
+		arguments << QString("-e"); //command to execute in konsole
+		arguments << settings.value(QString("executable"),QString()).toString(); //append executable tag
+		arguments << currentFile(); //append xml-file name
 		QProcess *cravaRun = new QProcess();
 		cravaRun->start(program,arguments);
 	}
@@ -4743,10 +4722,9 @@ void Main_crava::on_uncertaintyLevelLineEdit_editingFinished(){
 };//update the XML file with the uncertainty level
 
 void Main_crava::on_writeXmlPushButton_clicked(){
-	      if (okToRun()){ //has to save the file to run
-		on_runAction_triggered();
-		statusBar()->showMessage("Running CRAVA",2000);
-	}
+        okToRun(); //prompt to save crava if modified
+        on_runAction_triggered();//run crava 
+	statusBar()->showMessage("Running CRAVA",2000);
 }
 
 void Main_crava::on_areaSeismicRadioButton_toggled(bool checked){

--- a/trunk/SettingsDialog.cpp
+++ b/trunk/SettingsDialog.cpp
@@ -60,9 +60,6 @@ void SettingsDialog::updateFields(){
 	settings.beginGroup("crava");
 	cravaPathLineEdit->setText(settings.value(QString("executable"),QString("/project/res/x86_64_RH_5/bin/crava")).toString());
 	textEditorLineEdit->setText(settings.value(QString("editor"),QString("emacs")).toString());
-	terminalPathLineEdit->setText(settings.value(QString("terminal"),QString("konsole")).toString());
-	terminalCheckBox->setChecked(settings.value(QString("useterminal"),true).toBool());
-	on_terminalCheckBox_toggled(terminalCheckBox->isChecked());
 	wikiPathLineEdit->setText(settings.value(QString("wiki"),QString()).toString());
 	manualPathLineEdit->setText(settings.value(QString("manual"),QString("manual/CRAVA_user_manual.pdf")).toString());
 	settings.beginGroup("GUI");
@@ -254,8 +251,6 @@ void SettingsDialog::updateSettings(){
 		settings.setValue(QString("executable"),cravaPathLineEdit->text());
 	}
 	settings.setValue( QString("editor"), textEditorLineEdit->text() );
-	settings.setValue(QString("terminal"),terminalPathLineEdit->text());
-	settings.setValue(QString("useterminal"),terminalCheckBox->isChecked());
 	settings.setValue(QString("wiki"),wikiPathLineEdit->text());
 	settings.setValue(QString("manual"),manualPathLineEdit->text());
 	settings.beginGroup("GUI");
@@ -449,13 +444,6 @@ void SettingsDialog::on_textEditorBrowsePushButton_clicked(){
 	}
 }
 
-void SettingsDialog::on_terminalPathBrowsePushButton_clicked(){
-	QString fileName = QFileDialog::getOpenFileName(this, QString("Terminal"), standard->StandardStrings::inputPath(), QString("All files(*)"));//fix the file...
-	if(!fileName.isNull()){
-		terminalPathLineEdit->setText(fileName);
-	}
-}
-
 void SettingsDialog::on_seedFileBrowsePushButton_clicked(){
 	QString fileName = QFileDialog::getOpenFileName(this, QString("Seed file"), standard->StandardStrings::inputPath(), StandardStrings::asciiFormat());
 	if(!fileName.isNull()){
@@ -476,11 +464,6 @@ void SettingsDialog::on_manualPathBrowsePushButton_clicked(){
 	}
  }
 
-void SettingsDialog::on_terminalCheckBox_toggled(bool checked){
-	terminalPathLineEdit->setEnabled(checked);
-	terminalPathBrowsePushButton->setEnabled(checked);
-	terminalPathLabel->setEnabled(checked);
-}
 void SettingsDialog::on_segyCheckBox_toggled(bool checked){
 	if(!checked){
 		headerSeisWorksRadioButton->setChecked(true);

--- a/trunk/SettingsDialog.h
+++ b/trunk/SettingsDialog.h
@@ -50,11 +50,9 @@ private slots:
 	void on_reflectionMatrixBrowsePushButton_clicked();//files checked for legality on close of settings Updates the field with the selected file
 	void on_cravaPathBrowsePushButton_clicked();//files checked for legality on close of settings Updates the field with the selected file
 	void on_textEditorBrowsePushButton_clicked(); //Updates the field with the selected file
-	void on_terminalPathBrowsePushButton_clicked();//hard to check legality of commands? Updates the field with the selected file
 	void on_referenceTimeSurface3DPushButton_clicked();//files checked for legality on close of settings Updates the field with the selected file
 	void on_seedFileBrowsePushButton_clicked();//files checked for legality on close of settings Updates the field with the selected file
 	void on_manualPathBrowsePushButton_clicked();//files checked for legality on close of settings Updates the field with the selected file
-	void on_terminalCheckBox_toggled(bool checked);//makes the input for what terminal to run enabled/disabled.
 	void on_segyCheckBox_toggled(bool checked);//can only define header format if segy is selected.
 	void on_vpVsUserDefinedRadioButton_toggled(bool checked);//determines whether vpVsUserDefinedLineEdit is to be shown or not.
 };

--- a/trunk/SettingsDialog.ui
+++ b/trunk/SettingsDialog.ui
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <author>Øystein Monsrud Arneson and Andreas B. Lindblad</author>
+ <author>Alf Birger Rustad Øystein Monsrud Arneson and Andreas B. Lindblad</author>
  <class>SettingsDialog</class>
  <widget class="QDialog" name="SettingsDialog">
   <property name="geometry">
@@ -2002,43 +2002,6 @@ p, li { white-space: pre-wrap; }
           <widget class="QPushButton" name="textEditorBrowsePushButton">
            <property name="toolTip">
             <string>&lt;qt&gt;Choose the text editor which is to be used.</string>
-           </property>
-           <property name="text">
-            <string>Browse...</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QCheckBox" name="terminalCheckBox">
-           <property name="toolTip">
-            <string>&lt;qt&gt; Control whether CRAVA should run in the terminal or not.</string>
-           </property>
-           <property name="text">
-            <string>Run CRAVA in terminal</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0">
-          <widget class="QLabel" name="terminalPathLabel">
-           <property name="toolTip">
-            <string>&lt;qt&gt;The terminal application used for running CRAVA.</string>
-           </property>
-           <property name="text">
-            <string>Terminal application:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="1">
-          <widget class="QLineEdit" name="terminalPathLineEdit">
-           <property name="toolTip">
-            <string>&lt;qt&gt;The terminal application used for running CRAVA.</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="2">
-          <widget class="QPushButton" name="terminalPathBrowsePushButton">
-           <property name="toolTip">
-            <string>&lt;qt&gt;The terminal application used for running CRAVA.</string>
            </property>
            <property name="text">
             <string>Browse...</string>


### PR DESCRIPTION
Invoking a terminal and running Crava in it has been very fragile. The code is now simplified and cleaned up. Users will not be able to choose terminal, konsole will be used. Other terminals lack necessary functionality (e.g., gnome-terminal has no option to stay open).